### PR TITLE
Configurable secret names

### DIFF
--- a/lib/one_time_pass_ecto.ex
+++ b/lib/one_time_pass_ecto.ex
@@ -21,6 +21,9 @@ defmodule OneTimePassEcto do
         * the default is 30 (seconds)
       * `:window` - the number of attempts, before and after the current one, allowed
         * the default is 1 (1 interval before and 1 interval after)
+    * Both HOTP and TOTP
+      * `:otp_secret` - name of the Ecto field holding the secret (default :otp_secret)
+      * `:otp_last` - name of the Ecto field holding the last value (default :otp_last)
 
   See the documentation for the OneTimePassEcto.Base module for more details
   about generating and verifying one-time passwords.

--- a/test/one_time_pass_ecto_test.exs
+++ b/test/one_time_pass_ecto_test.exs
@@ -7,7 +7,7 @@ defmodule OneTimePassEctoTest do
   setup context do
     %{id: user_id} = UserHelper.add_user()
     otp_last = context[:last] || 0
-    update_repo(user_id, otp_last)
+    update_repo(user_id, otp_last: otp_last)
     {:ok, %{user_id: user_id}}
   end
 
@@ -15,9 +15,9 @@ defmodule OneTimePassEctoTest do
     OneTimePassEcto.verify(params, TestRepo, TestUser, opts)
   end
 
-  def update_repo(user_id, otp_last) do
+  def update_repo(user_id, changes \\ []) do
     TestRepo.get(TestUser, user_id)
-    |> change(%{otp_last: otp_last})
+    |> change(changes)
     |> TestRepo.update!()
   end
 
@@ -42,6 +42,23 @@ defmodule OneTimePassEctoTest do
     assert message
   end
 
+  test "check hotp using different secret blocks access using original hotp secret", %{user_id: user_id} do
+    user = %{"hotp" => "816065", "id" => user_id}
+    {:error, "invalid one-time password"} =
+      login(user, otp_secret: :second_otp_secret, otp_last: :second_otp_last)
+  end
+  
+  test "check hotp using alternate secret", %{user_id: user_id} do
+    opts = [otp_secret: :second_otp_secret, otp_last: :second_otp_last]
+    user = %{"hotp" => "563998", "id" => user_id}
+    {:ok, %{id: id, second_otp_last: otp_last}} = login(user, opts)
+    assert id == user_id
+    assert otp_last == 1
+    fail = %{"hotp" => "563999", "id" => user_id}
+    {:error, message} = login(fail, opts)
+    assert message
+  end
+
   test "check totp with default options", %{user_id: user_id} do
     token = OneTimePassEcto.Base.gen_totp("MFRGGZDFMZTWQ2LK")
     user = %{"totp" => token, "id" => user_id}
@@ -49,11 +66,18 @@ defmodule OneTimePassEctoTest do
     assert user
   end
 
+  test "check totp with default options and alternate secret", %{user_id: user_id} do
+    token = OneTimePassEcto.Base.gen_totp("E4IX6ABMKZX7GN56")
+    user = %{"totp" => token, "id" => user_id}
+    {:ok, user} = login(user, otp_secret: :second_otp_secret, otp_last: :second_otp_last)
+    assert user
+  end
+
   test "disallow totp check with same token", %{user_id: user_id} do
     token = OneTimePassEcto.Base.gen_totp("MFRGGZDFMZTWQ2LK")
     user = %{"totp" => token, "id" => user_id}
     {:ok, %{otp_last: otp_last}} = login(user, [])
-    update_repo(user_id, otp_last)
+    update_repo(user_id, otp_last: otp_last)
     {:error, message} = login(user, [])
     assert message
   end
@@ -62,7 +86,7 @@ defmodule OneTimePassEctoTest do
     token = OneTimePassEcto.Base.gen_totp("MFRGGZDFMZTWQ2LK")
     user = %{"totp" => token, "id" => user_id}
     {:ok, %{otp_last: otp_last}} = login(user, [])
-    update_repo(user_id, otp_last)
+    update_repo(user_id, otp_last: otp_last)
     new_token = OneTimePassEcto.Base.gen_hotp("MFRGGZDFMZTWQ2LK", otp_last - 1)
     user = %{"totp" => new_token, "id" => user_id}
     {:error, message} = login(user, [])

--- a/test/support/ecto_helper.exs
+++ b/test/support/ecto_helper.exs
@@ -31,6 +31,8 @@ defmodule UsersMigration do
       add(:otp_required, :boolean)
       add(:otp_secret, :string)
       add(:otp_last, :integer)
+      add(:second_otp_secret, :string)
+      add(:second_otp_last, :integer)
     end
 
     create(unique_index(:users, [:email]))
@@ -45,6 +47,8 @@ defmodule OneTimePassEcto.TestUser do
     field(:otp_required, :boolean)
     field(:otp_secret, :string)
     field(:otp_last, :integer)
+    field(:second_otp_secret, :string)
+    field(:second_otp_last, :integer)
   end
 end
 

--- a/test/support/user_helper.exs
+++ b/test/support/user_helper.exs
@@ -6,7 +6,9 @@ defmodule OneTimePassEcto.UserHelper do
     email: "brian@mail.com",
     otp_required: true,
     otp_secret: "MFRGGZDFMZTWQ2LK",
-    otp_last: 0
+    otp_last: 0,
+    second_otp_secret: "E4IX6ABMKZX7GN56",
+    second_otp_last: 0
   }
 
   def add_user(attrs \\ @attrs) do


### PR DESCRIPTION
Allows the Ecto field names `otp_secret` and `otp_last` to be configured by passing `:otp_secret` and `:otp_last` options into `verify/4`. 

This allows the field names to differ from the defaults -- and also allows more than one OTP context per user in cases where users might be authenticated into different contexts.